### PR TITLE
Update the Excel Data Reader to the version 3.1.0

### DIFF
--- a/src/ExcelMapper.csproj
+++ b/src/ExcelMapper.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.ValueTuple" Version="4.3.0" />
-    <PackageReference Include="ExcelDataReader" Version="3.0.0-develop00086" />
+    <PackageReference Include="ExcelDataReader" Version="3.1.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Mappings/Readers/ColumnIndexReader.cs
+++ b/src/Mappings/Readers/ColumnIndexReader.cs
@@ -29,7 +29,8 @@ namespace ExcelMapper.Mappings.Readers
 
         public ReadCellValueResult GetValue(ExcelSheet sheet, int rowIndex, IExcelDataReader reader)
         {
-            return new ReadCellValueResult(ColumnIndex, reader.GetString(ColumnIndex));
+            var value = reader[ColumnIndex]?.ToString();
+            return new ReadCellValueResult(ColumnIndex, value);
         }
     }
 }

--- a/src/Mappings/Readers/ColumnNameReader.cs
+++ b/src/Mappings/Readers/ColumnNameReader.cs
@@ -34,8 +34,9 @@ namespace ExcelMapper.Mappings.Readers
 
         public ReadCellValueResult GetValue(ExcelSheet sheet, int rowIndex, IExcelDataReader reader)
         {
-            int index = sheet.Heading.GetColumnIndex(ColumnName);
-            return new ReadCellValueResult(index, reader.GetString(index));
+            var index = sheet.Heading.GetColumnIndex(ColumnName);
+            var value = reader[index]?.ToString();
+            return new ReadCellValueResult(index, value);
         }
     }
 }

--- a/src/Mappings/Readers/MultipleColumnIndicesValueReader.cs
+++ b/src/Mappings/Readers/MultipleColumnIndicesValueReader.cs
@@ -46,7 +46,11 @@ namespace ExcelMapper.Mappings.Readers
 
         public IEnumerable<ReadCellValueResult> GetValues(ExcelSheet sheet, int rowIndex, IExcelDataReader reader)
         {
-            return ColumnIndices.Select(i => new ReadCellValueResult(i, reader.GetString(i)));
+            return ColumnIndices.Select(columnIndex =>
+            {
+                var value = reader[columnIndex]?.ToString();
+                return new ReadCellValueResult(columnIndex, value);
+            });
         }
     }
 }

--- a/src/Mappings/Readers/MultipleColumnNamesValueReader.cs
+++ b/src/Mappings/Readers/MultipleColumnNamesValueReader.cs
@@ -48,8 +48,9 @@ namespace ExcelMapper.Mappings.Readers
         {
             return ColumnNames.Select(columnName =>
             {
-                int index = sheet.Heading.GetColumnIndex(columnName);
-                return new ReadCellValueResult(index, reader.GetString(index));
+                var index = sheet.Heading.GetColumnIndex(columnName);
+                var value = reader[index]?.ToString();
+                return new ReadCellValueResult(index, value);
             });
         }
     }


### PR DESCRIPTION
Since the version 3.0.0 the methods `IDataReader.Get*` don't automatically convert the
field value to the requested type. See the release notes for more information:
https://github.com/ExcelDataReader/ExcelDataReader/releases/tag/v3.0.0