### PR TITLE
Auto register mapper classes by namespace

### DIFF
--- a/src/ExcelMapper.csproj
+++ b/src/ExcelMapper.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.4;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -20,8 +20,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
-    <PackageReference Include="ExcelDataReader" Version="3.1.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
+    <PackageReference Include="ExcelDataReader" Version="3.2.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/ExcelMapper.csproj
+++ b/src/ExcelMapper.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.4;net46</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/ExcelMapper.csproj
+++ b/src/ExcelMapper.csproj
@@ -20,6 +20,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Reflection" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="ExcelDataReader" Version="3.2.0" />
   </ItemGroup>

--- a/src/Utilities/ExcelImporterUtils.cs
+++ b/src/Utilities/ExcelImporterUtils.cs
@@ -9,29 +9,29 @@ namespace ExcelMapper
     {
 #if NETSTANDARD2_0
         public static IEnumerable<ExcelClassMap> RegisterClassMapsInNamespace(this ExcelImporter importer,
-            string nameSpace)
+            string namespaceString)
         {
-            return RegisterClassMapsInNamespace(importer, Assembly.GetExecutingAssembly(), nameSpace);
+            return RegisterClassMapsInNamespace(importer, Assembly.GetExecutingAssembly(), namespaceString);
         }
 #endif
 
         public static IEnumerable<ExcelClassMap> RegisterClassMapsInNamespace(this ExcelImporter importer,
             Assembly assembly,
-            string nameSpace)
+            string namespaceString)
         {
-            if (nameSpace == null)
+            if (namespaceString == null)
             {
-                throw new ArgumentNullException(nameof(nameSpace));
+                throw new ArgumentNullException(nameof(namespaceString));
             }
 
-            if (nameSpace.Length == 0)
+            if (namespaceString.Length == 0)
             {
-                throw new ArgumentException("The namespace cannot be empty.", nameof(nameSpace));
+                throw new ArgumentException("The namespace cannot be empty.", nameof(namespaceString));
             }
 
             var classes = assembly
                 .GetTypes()
-                .Where(t => t.IsAssignableFrom(typeof(ExcelClassMap)) && t.Namespace == nameSpace);
+                .Where(t => t.IsAssignableFrom(typeof(ExcelClassMap)) && t.Namespace == namespaceString);
 
             var objects = classes.Select(Activator.CreateInstance).OfType<ExcelClassMap>().ToList();
 

--- a/src/Utilities/ExcelImporterUtils.cs
+++ b/src/Utilities/ExcelImporterUtils.cs
@@ -7,7 +7,9 @@ namespace ExcelMapper.Utilities
 {
     public static class ExcelImporterUtils
     {
-        public static List<ExcelClassMap> RegisterMapperClassesByNamespace(this ExcelImporter importer, string namespacestr)
+#if NETSTANDARD2_0
+        public static List<ExcelClassMap> RegisterMapperClassesByNamespace(this ExcelImporter importer,
+            string namespacestr)
         {
             var classes = Assembly.GetExecutingAssembly()
                 .GetTypes().AsParallel()
@@ -21,5 +23,6 @@ namespace ExcelMapper.Utilities
 
             return objects;
         }
+#endif
     }
 }

--- a/src/Utilities/ExcelImporterUtils.cs
+++ b/src/Utilities/ExcelImporterUtils.cs
@@ -8,15 +8,24 @@ namespace ExcelMapper
     public static class ExcelImporterUtils
     {
 #if NETSTANDARD2_0
-        public static List<ExcelClassMap> RegisterMapperClassesByNamespace(this ExcelImporter importer,
-            string namespacestr)
+        public static IEnumerable<ExcelClassMap> RegisterMapperClassesByNamespace(this ExcelImporter importer,
+            string nameSpace)
         {
+            if (nameSpace == null)
+            {
+                throw new ArgumentNullException(nameof(nameSpace));
+            }
+
+            if (nameSpace.Length == 0)
+            {
+                throw new ArgumentException("The namespace cannot be empty.", nameof(nameSpace));
+            }
+
             var classes = Assembly.GetExecutingAssembly()
                 .GetTypes().AsParallel()
-                .Where(t => t.IsClass && t.Namespace == namespacestr);
+                .Where(t => t.IsAssignableFrom(typeof(ExcelClassMap)) && t.Namespace == nameSpace);
 
-            var objects = classes.AsParallel().Select(Activator.CreateInstance)
-                .AsParallel().OfType<ExcelClassMap>().ToList();
+            var objects = classes.AsParallel().Select(Activator.CreateInstance).OfType<ExcelClassMap>().ToList();
 
             foreach (var o in objects)
                 importer.Configuration.RegisterClassMap(o);

--- a/src/Utilities/ExcelImporterUtils.cs
+++ b/src/Utilities/ExcelImporterUtils.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
-namespace ExcelMapper.Utilities
+namespace ExcelMapper
 {
     public static class ExcelImporterUtils
     {

--- a/src/Utilities/ExcelImporterUtils.cs
+++ b/src/Utilities/ExcelImporterUtils.cs
@@ -8,7 +8,15 @@ namespace ExcelMapper
     public static class ExcelImporterUtils
     {
 #if NETSTANDARD2_0
-        public static IEnumerable<ExcelClassMap> RegisterMapperClassesByNamespace(this ExcelImporter importer,
+        public static IEnumerable<ExcelClassMap> RegisterClassMapsInNamespace(this ExcelImporter importer,
+            string nameSpace)
+        {
+            return RegisterClassMapsInNamespace(importer, Assembly.GetExecutingAssembly(), nameSpace);
+        }
+#endif
+
+        public static IEnumerable<ExcelClassMap> RegisterClassMapsInNamespace(this ExcelImporter importer,
+            Assembly assembly,
             string nameSpace)
         {
             if (nameSpace == null)
@@ -21,17 +29,16 @@ namespace ExcelMapper
                 throw new ArgumentException("The namespace cannot be empty.", nameof(nameSpace));
             }
 
-            var classes = Assembly.GetExecutingAssembly()
-                .GetTypes().AsParallel()
+            var classes = assembly
+                .GetTypes()
                 .Where(t => t.IsAssignableFrom(typeof(ExcelClassMap)) && t.Namespace == nameSpace);
 
-            var objects = classes.AsParallel().Select(Activator.CreateInstance).OfType<ExcelClassMap>().ToList();
+            var objects = classes.Select(Activator.CreateInstance).OfType<ExcelClassMap>().ToList();
 
             foreach (var o in objects)
                 importer.Configuration.RegisterClassMap(o);
 
             return objects;
         }
-#endif
     }
 }

--- a/src/Utilities/ExcelImporterUtils.cs
+++ b/src/Utilities/ExcelImporterUtils.cs
@@ -20,19 +20,13 @@ namespace ExcelMapper
             string namespaceString)
         {
             if (namespaceString == null)
-            {
                 throw new ArgumentNullException(nameof(namespaceString));
-            }
 
             if (namespaceString.Length == 0)
-            {
                 throw new ArgumentException("The namespace cannot be empty.", nameof(namespaceString));
-            }
 
             if (!assembly.GetTypes().Any())
-            {
                 throw new ArgumentException("The assembly doesn't have any types.", nameof(assembly));
-            }
 
             var classes = assembly
                 .GetTypes()
@@ -41,9 +35,7 @@ namespace ExcelMapper
             var objects = classes.Select(Activator.CreateInstance).OfType<ExcelClassMap>().ToList();
 
             if (!objects.Any())
-            {
                 throw new ArgumentException("No classmaps found in this namespace.", nameof(assembly));
-            }
 
             foreach (var o in objects)
                 importer.Configuration.RegisterClassMap(o);

--- a/src/Utilities/ExcelImporterUtils.cs
+++ b/src/Utilities/ExcelImporterUtils.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace ExcelMapper.Utilities
+{
+    public static class ExcelImporterUtils
+    {
+        public static List<ExcelClassMap> RegisterMapperClassesByNamespace(this ExcelImporter importer, string namespacestr)
+        {
+            var classes = Assembly.GetExecutingAssembly()
+                .GetTypes().AsParallel()
+                .Where(t => t.IsClass && t.Namespace == namespacestr);
+
+            var objects = classes.AsParallel().Select(Activator.CreateInstance)
+                .AsParallel().OfType<ExcelClassMap>().ToList();
+
+            foreach (var o in objects)
+                importer.Configuration.RegisterClassMap(o);
+
+            return objects;
+        }
+    }
+}

--- a/src/Utilities/ExcelImporterUtils.cs
+++ b/src/Utilities/ExcelImporterUtils.cs
@@ -29,11 +29,21 @@ namespace ExcelMapper
                 throw new ArgumentException("The namespace cannot be empty.", nameof(namespaceString));
             }
 
+            if (!assembly.GetTypes().Any())
+            {
+                throw new ArgumentException("The assembly doesn't have any types.", nameof(assembly));
+            }
+
             var classes = assembly
                 .GetTypes()
                 .Where(t => t.IsAssignableFrom(typeof(ExcelClassMap)) && t.Namespace == namespaceString);
 
             var objects = classes.Select(Activator.CreateInstance).OfType<ExcelClassMap>().ToList();
+
+            if (!objects.Any())
+            {
+                throw new ArgumentException("No classmaps found in this namespace.", nameof(assembly));
+            }
 
             foreach (var o in objects)
                 importer.Configuration.RegisterClassMap(o);

--- a/tests/ExcelMapper.Tests.csproj
+++ b/tests/ExcelMapper.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;net46</TargetFrameworks>
     <ApplicationIcon />
     <OutputTypeEx>exe</OutputTypeEx>
     <StartupObject />

--- a/tests/ExcelMapper.Tests.csproj
+++ b/tests/ExcelMapper.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net46</TargetFrameworks>
     <ApplicationIcon />
     <OutputTypeEx>exe</OutputTypeEx>
     <StartupObject />

--- a/tests/ExcelMapper.Tests.csproj
+++ b/tests/ExcelMapper.Tests.csproj
@@ -63,15 +63,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenCover" Version="4.6.519" />
-    <PackageReference Include="ReportGenerator" Version="3.0.2" />
-    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.analyzers" Version="0.7.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0" />
+	<PackageReference Include="ReportGenerator" Version="2.5.10" />
+    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
+    <PackageReference Include="xunit.analyzers" Version="0.5.0" />
+    <PackageReference Include="xunit.runner.console" Version="2.3.0-beta3-build3705" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ExcelMapper.Tests.csproj
+++ b/tests/ExcelMapper.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
     <ApplicationIcon />
     <OutputTypeEx>exe</OutputTypeEx>
     <StartupObject />
@@ -64,14 +64,14 @@
 
   <ItemGroup>
     <PackageReference Include="OpenCover" Version="4.6.519" />
-    <PackageReference Include="ReportGenerator" Version="2.5.10" />
+    <PackageReference Include="ReportGenerator" Version="3.0.2" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
-    <PackageReference Include="xunit.analyzers" Version="0.5.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.3.0-beta3-build3705" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.3.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.analyzers" Version="0.7.0" />
+    <PackageReference Include="xunit.runner.console" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ExcelMapper.Tests.csproj
+++ b/tests/ExcelMapper.Tests.csproj
@@ -63,13 +63,13 @@
   </ItemGroup>
 
   <ItemGroup>
-	<PackageReference Include="ReportGenerator" Version="2.5.10" />
-    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
-    <PackageReference Include="xunit.analyzers" Version="0.5.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.3.0-beta3-build3705" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
+	<PackageReference Include="ReportGenerator" Version="3.0.2" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.analyzers" Version="0.7.0" />
+    <PackageReference Include="xunit.runner.console" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.3.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Title says it all.

### Usage
```csharp
using (var stream = File.OpenRead(FILEPATH))
using (var importer = new ExcelImporter(stream))
{
    importer.RegisterMapperClassesByNamespace("NAMESPACE");
    return importer.ReadSheet().ReadRows<T>().ToArray();
}
```

**(This have broken the tests)**