### PR TITLE
Fix case sensetive heading dictionary

### DIFF
--- a/src/ExcelHeading.cs
+++ b/src/ExcelHeading.cs
@@ -14,7 +14,7 @@ namespace ExcelMapper
 
         internal ExcelHeading(IDataRecord reader)
         {
-            var nameMapping = new Dictionary<string, int>(reader.FieldCount);
+            var nameMapping = new Dictionary<string, int>(reader.FieldCount, StringComparer.OrdinalIgnoreCase);
             var columnNames = new string[reader.FieldCount];
 
             for (int columnIndex = 0; columnIndex < reader.FieldCount; columnIndex++)


### PR DESCRIPTION
Trying to import this excelfile and getting the error ` {"Column "Pris" does not exist in ["id", "priskod", "kategori", "pris", "antalnr", "tidningid", "ejetikett"]"} | ExcelMapper.ExcelMappingException` 
from `ExcelHeading.cs` row 60 `            if (!NameMapping.TryGetValue(columnName, out int index))
`

The dictionary is case sensitive, of course I can get around it using `.WithColumnName("pris")` on the mapping class, but that seems to be a bit unnecessary.


My test data and code:

id | priskod | kategori | pris | antalnr | tidningid | ejetikett
-- | -- | -- | -- | -- | -- | --
1 | 0 | Helår | 299 | 8 | 1 | -1
2 | 1 | 10ex249 | 249 | 10 | 1 | -1

```C# 
public class Priskod
{
	public int Id { get; set; }
	public int Kod { get; set; }
	public string Namn { get; set; }
	public decimal Pris { get; set; }
	public int Antalnr { get; set; }
}

public class PriskodClassMap : ExcelClassMap<Priskod>
{
	public PriskodClassMap()
	{
		Map(p => p.Kod)
			.WithConverter(value => int.Parse(value))
			.WithColumnName("priskod");

		Map(p => p.Namn)
			.WithColumnName("kategori");

		Map(p => p.Pris)
			.WithConverter(value => decimal.Parse(value));

		Map(p => p.Antalnr)
			.WithConverter(value => int.Parse(value));
	}
}

using (var importer = new ExcelImporter(stream))
{
	importer.Configuration.RegisterClassMap<PriskodClassMap>();

	ExcelSheet sheet = importer.ReadSheet();
	var priskoder = sheet.ReadRows<Priskod>().ToArray();
}