### PR TITLE
Add support for cast expressions

### DIFF
--- a/tests/ExcelMapper/ExcelClassMapTests.cs
+++ b/tests/ExcelMapper/ExcelClassMapTests.cs
@@ -7,6 +7,30 @@ namespace ExcelMapper.Tests
     public class ExcelClassMapTests : ExcelClassMap<Helpers.TestClass>
     {
         [Fact]
+        public void Map_SingleExpression_Success()
+        {
+            Assert.Equal("Value", Map(p => p.Value).Member.Name);
+        }
+
+        [Fact]
+        public void Map_NestedExpression_Success()
+        {
+            Assert.Equal("IntValue", Map(p => p.NestedValue.IntValue).Member.Name);
+        }
+
+        [Fact]
+        public void Map_CastExpression_Success()
+        {
+            Assert.Equal("Value", Map(p => (string)p.Value).Member.Name);
+        }
+
+        [Fact]
+        public void Map_NestedCastExpression_Success()
+        {
+            Assert.Equal("IntValue", Map(p => (int)p.NestedValue.IntValue).Member.Name);
+        }
+
+        [Fact]
         public void Map_ExpressionNotMemberExpression_ThrowsArgumentException()
         {
             Assert.Throws<ArgumentException>("expression", () => Map(p => new List<string>()));
@@ -81,6 +105,33 @@ namespace ExcelMapper.Tests
         }
 
         [Fact]
+        public void Map_InvalidUnaryExpression_ThrowsArgumentException()
+        {
+            var otherType = new OtherType();
+            Assert.Throws<ArgumentException>("expression", () => Map(p => -otherType.Value));
+        }
+
+        [Fact]
+        public void Map_InvalidBinaryExpression_ThrowsArgumentException()
+        {
+            var otherType = new OtherType();
+            Assert.Throws<ArgumentException>("expression", () => Map(p => otherType.Value + 1));
+        }
+
+        [Fact]
+        public void Map_InvalidMethodExpression_ThrowsArgumentException()
+        {
+            var otherType = new OtherType();
+            Assert.Throws<ArgumentException>("expression", () => Map(p => otherType.Value.ToString()));
+        }
+
+        [Fact]
+        public void Map_InvalidCastExpression_ThrowsExcelMappingException()
+        {
+            Assert.Throws<ExcelMappingException>(() => Map(p => (CollectionAttribute)p.ObjectValue));
+        }
+
+        [Fact]
         public void Map_MultipleMemberAccessTypeAlreadyMapped_ThrowsInvalidOperationException()
         {
             var iconvertibleType = new IConvertibleType();
@@ -99,95 +150,44 @@ namespace ExcelMapper.Tests
         {
             public string Value { get; set; }
 
-            public TypeCode GetTypeCode()
-            {
-                throw new NotImplementedException();
-            }
+            public TypeCode GetTypeCode() => throw new NotImplementedException();
 
-            public bool ToBoolean(IFormatProvider provider)
-            {
-                throw new NotImplementedException();
-            }
+            public bool ToBoolean(IFormatProvider provider) => throw new NotImplementedException();
 
-            public byte ToByte(IFormatProvider provider)
-            {
-                throw new NotImplementedException();
-            }
+            public byte ToByte(IFormatProvider provider) => throw new NotImplementedException();
 
-            public char ToChar(IFormatProvider provider)
-            {
-                throw new NotImplementedException();
-            }
+            public char ToChar(IFormatProvider provider) => throw new NotImplementedException();
 
-            public DateTime ToDateTime(IFormatProvider provider)
-            {
-                throw new NotImplementedException();
-            }
+            public DateTime ToDateTime(IFormatProvider provider) => throw new NotImplementedException();
 
-            public decimal ToDecimal(IFormatProvider provider)
-            {
-                throw new NotImplementedException();
-            }
+            public decimal ToDecimal(IFormatProvider provider) => throw new NotImplementedException();
 
-            public double ToDouble(IFormatProvider provider)
-            {
-                throw new NotImplementedException();
-            }
+            public double ToDouble(IFormatProvider provider) => throw new NotImplementedException();
 
-            public short ToInt16(IFormatProvider provider)
-            {
-                throw new NotImplementedException();
-            }
+            public short ToInt16(IFormatProvider provider) => throw new NotImplementedException();
 
-            public int ToInt32(IFormatProvider provider)
-            {
-                throw new NotImplementedException();
-            }
+            public int ToInt32(IFormatProvider provider) => throw new NotImplementedException();
 
-            public long ToInt64(IFormatProvider provider)
-            {
-                throw new NotImplementedException();
-            }
+            public long ToInt64(IFormatProvider provider) => throw new NotImplementedException();
 
-            public sbyte ToSByte(IFormatProvider provider)
-            {
-                throw new NotImplementedException();
-            }
+            public sbyte ToSByte(IFormatProvider provider) => throw new NotImplementedException();
 
-            public float ToSingle(IFormatProvider provider)
-            {
-                throw new NotImplementedException();
-            }
+            public float ToSingle(IFormatProvider provider) => throw new NotImplementedException();
 
-            public string ToString(IFormatProvider provider)
-            {
-                throw new NotImplementedException();
-            }
+            public string ToString(IFormatProvider provider) => throw new NotImplementedException();
 
-            public object ToType(Type conversionType, IFormatProvider provider)
-            {
-                throw new NotImplementedException();
-            }
+            public object ToType(Type conversionType, IFormatProvider provider) => throw new NotImplementedException();
 
-            public ushort ToUInt16(IFormatProvider provider)
-            {
-                throw new NotImplementedException();
-            }
+            public ushort ToUInt16(IFormatProvider provider) => throw new NotImplementedException();
 
-            public uint ToUInt32(IFormatProvider provider)
-            {
-                throw new NotImplementedException();
-            }
+            public uint ToUInt32(IFormatProvider provider) => throw new NotImplementedException();
 
-            public ulong ToUInt64(IFormatProvider provider)
-            {
-                throw new NotImplementedException();
-            }
+            public ulong ToUInt64(IFormatProvider provider) => throw new NotImplementedException();
         }
 
         public class OtherType
         {
-            public string Value { get; set; }
+            public int Value { get; set; }
         }
 
         [Theory]

--- a/tests/Helpers.cs
+++ b/tests/Helpers.cs
@@ -27,6 +27,8 @@ namespace ExcelMapper.Tests
         public class TestClass
         {
             public string Value { get; set; }
+            public object ObjectValue { get; set; }
+            public NestedClass NestedValue { get; set; }
             public DateTime DateValue { get; set; }
             public DateTime? NullableDateValue { get; set; }
             public IListInterface UnknownInterfaceValue { get; set; }
@@ -40,6 +42,11 @@ namespace ExcelMapper.Tests
             public InvalidIDictionaryMemberType InvalidIDictionaryMemberType { get; set; }
 
             public event EventHandler Event { add { } remove { } }
+
+            public class NestedClass
+            {
+                public int IntValue { get; set; }
+            }
         }
 
         public class InvalidIListMemberType

--- a/tests/Maps/MapForced.cs
+++ b/tests/Maps/MapForced.cs
@@ -1,0 +1,44 @@
+using Xunit;
+
+namespace ExcelMapper.Tests
+{
+    public class MapForced
+    {
+        [Fact]
+        public void ReadRow_ForcedMappedInt32_Success()
+        {
+            using var importer = Helpers.GetImporter("Numbers.xlsx");
+            importer.Configuration.RegisterClassMap<ForcedInt32ValueMap>();
+
+            ExcelSheet sheet = importer.ReadSheet();
+            sheet.ReadHeading();
+
+            // Valid cell value.
+            ObjectValue row1 = sheet.ReadRow<ObjectValue>();
+            Assert.Equal(2, row1.Value);
+
+            // Empty cell value.
+            ObjectValue row2 = sheet.ReadRow<ObjectValue>();
+            Assert.Equal(-10, row2.Value);
+
+            // Invalid cell value.
+            ObjectValue row3 = sheet.ReadRow<ObjectValue>();
+            Assert.Equal(10, row3.Value);
+        }
+
+        private class ObjectValue
+        {
+            public object Value { get; set; }
+        }
+
+        private class ForcedInt32ValueMap : ExcelClassMap<ObjectValue>
+        {
+            public ForcedInt32ValueMap()
+            {
+                Map(o => (int)o.Value)
+                    .WithEmptyFallback(-10)
+                    .WithInvalidFallback(10);
+            }
+        }
+    }
+}


### PR DESCRIPTION
E.g. `Map(p => (string)p.Value)`. Useful to force things to parse a certain way e.g. object.