### PR TITLE
Storing the row index inside the ReadCellValueResult struct

### DIFF
--- a/src/Abstractions/ReadCellValueResult.cs
+++ b/src/Abstractions/ReadCellValueResult.cs
@@ -16,14 +16,21 @@
         public string StringValue { get; }
 
         /// <summary>
+        /// The index of the row that contains the cell.
+        /// </summary>
+        public int RowIndex { get; set; }
+
+        /// <summary>
         /// Constructs an object describing the output of reading the value of a single cell.
         /// </summary>
         /// <param name="columnIndex">The index of the column that contains the cell.</param>
+        /// <param name="rowIndex">The index of the row that contains the cell.</param>
         /// <param name="stringValue">The string value of the cell.</param>
-        public ReadCellValueResult(int columnIndex, string stringValue)
+        public ReadCellValueResult(int columnIndex, int rowIndex, string stringValue)
         {
             ColumnIndex = columnIndex;
             StringValue = stringValue;
+            RowIndex = rowIndex;
         }
     }
 }

--- a/src/IValuePipelineExtensions.cs
+++ b/src/IValuePipelineExtensions.cs
@@ -8,7 +8,7 @@ using ExcelMapper.Transformers;
 
 namespace ExcelMapper
 {
-    public delegate T ConvertUsingSimpleMapperDelegate<out T>(string stringValue);
+    public delegate T ConvertUsingSimpleMapperDelegate<out T>(ReadCellValueResult cell);
 
     /// <summary>
     /// Extensions on IValuePipeline to enable fluent "With" method chaining.
@@ -156,7 +156,7 @@ namespace ExcelMapper
         /// <typeparam name="TPropertyMap">The type of the property map.</typeparam>
         /// <typeparam name="T">The type of the property or field that the property map represents.</typeparam>
         /// <param name="propertyMap">The property map to use.</param>
-        /// <param name="converter">A delegate that is invoked to map the string value of a cell to the value of a property or field.</param>
+        /// <param name="converter">A delegate that is invoked to map the cell value to the value of a property or field.</param>
         /// <returns>The property map on which this method was invoked.</returns>
         public static TPropertyMap WithConverter<TPropertyMap, T>(this TPropertyMap propertyMap, ConvertUsingSimpleMapperDelegate<T> converter) where TPropertyMap : IValuePipeline<T>
         {
@@ -169,7 +169,7 @@ namespace ExcelMapper
             {
                 try
                 {
-                    value = converter(mapResult.StringValue);
+                    value = converter(mapResult);
                     return PropertyMapperResultType.Success;
                 }
                 catch

--- a/src/Readers/AllColumnNamesValueReader.cs
+++ b/src/Readers/AllColumnNamesValueReader.cs
@@ -21,7 +21,7 @@ namespace ExcelMapper.Readers
             {
                 var index = sheet.Heading.GetColumnIndex(columnName);
                 var value = reader[index]?.ToString();
-                return new ReadCellValueResult(index, value);
+                return new ReadCellValueResult(index, rowIndex, value);
             });
             return true;
         }

--- a/src/Readers/ColumnIndexReader.cs
+++ b/src/Readers/ColumnIndexReader.cs
@@ -37,7 +37,7 @@ namespace ExcelMapper.Readers
             }
 
             var value = reader[ColumnIndex]?.ToString();
-            result = new ReadCellValueResult(ColumnIndex, value);
+            result = new ReadCellValueResult(ColumnIndex, rowIndex, value);
             return true;
         }
     }

--- a/src/Readers/ColumnNameMatchingValueReader.cs
+++ b/src/Readers/ColumnNameMatchingValueReader.cs
@@ -34,7 +34,7 @@ namespace ExcelMapper.Readers
             }
 
             string value = reader[index]?.ToString();
-            result = new ReadCellValueResult(index, value);
+            result = new ReadCellValueResult(index, rowIndex, value);
             return true;
         }
     }

--- a/src/Readers/ColumnNameReader.cs
+++ b/src/Readers/ColumnNameReader.cs
@@ -47,7 +47,7 @@ namespace ExcelMapper.Readers
             }
 
             string value = reader[index]?.ToString();
-            result = new ReadCellValueResult(index, value);
+            result = new ReadCellValueResult(index, rowIndex, value);
             return true;
         }
     }

--- a/src/Readers/MultipleColumnIndicesValueReader.cs
+++ b/src/Readers/MultipleColumnIndicesValueReader.cs
@@ -50,7 +50,7 @@ namespace ExcelMapper.Readers
             result = ColumnIndices.Select(columnIndex =>
             {
                 var value = reader[columnIndex]?.ToString();
-                return new ReadCellValueResult(columnIndex, value);
+                return new ReadCellValueResult(columnIndex, rowIndex, value);
             });
             return true;
         }

--- a/src/Readers/MultipleColumnNamesValueReader.cs
+++ b/src/Readers/MultipleColumnNamesValueReader.cs
@@ -62,7 +62,7 @@ namespace ExcelMapper.Readers
                 }
 
                 var value = reader[index]?.ToString();
-                values[i] = new ReadCellValueResult(index, value);
+                values[i] = new ReadCellValueResult(index, rowIndex, value);
             }
 
             result = values;

--- a/src/Readers/SplitCellValueReader.cs
+++ b/src/Readers/SplitCellValueReader.cs
@@ -54,7 +54,7 @@ namespace ExcelMapper.Readers
             }
 
             string[] splitStringValues = GetValues(readResult.StringValue);
-            result = splitStringValues.Select(s => new ReadCellValueResult(readResult.ColumnIndex, s));
+            result = splitStringValues.Select(s => new ReadCellValueResult(readResult.ColumnIndex, readResult.RowIndex, s));
             return true;
         }
 

--- a/src/ValuePipeline.cs
+++ b/src/ValuePipeline.cs
@@ -81,7 +81,7 @@ namespace ExcelMapper
         {
             foreach (ICellValueTransformer transformer in pipeline.CellValueTransformers)
             {
-                readResult = new ReadCellValueResult(readResult.ColumnIndex, transformer.TransformStringValue(sheet, rowIndex, readResult));
+                readResult = new ReadCellValueResult(readResult.ColumnIndex, readResult.RowIndex, transformer.TransformStringValue(sheet, rowIndex, readResult));
             }
 
             if (string.IsNullOrEmpty(readResult.StringValue) && pipeline.EmptyFallback != null)

--- a/tests/ExcelMapper/Abstractions/ReadCellValueResultTests.cs
+++ b/tests/ExcelMapper/Abstractions/ReadCellValueResultTests.cs
@@ -13,13 +13,14 @@ namespace ExcelMapper.Abstractions.Tests
         }
 
         [Theory]
-        [InlineData(-1, null)]
-        [InlineData(0, "")]
-        [InlineData(2, "abc")]
-        public void Ctor_ColumnIndex_StringValue(int columnIndex, string stringValue)
+        [InlineData(-1, -1, null)]
+        [InlineData(0, 0, "")]
+        [InlineData(2, 2, "abc")]
+        public void Ctor_ColumnIndex_StringValue(int columnIndex, int rowIndex, string stringValue)
         {
-            var result = new ReadCellValueResult(columnIndex, stringValue);
+            var result = new ReadCellValueResult(columnIndex, rowIndex, stringValue);
             Assert.Equal(columnIndex, result.ColumnIndex);
+            Assert.Equal(rowIndex, result.RowIndex);
             Assert.Equal(stringValue, result.StringValue);
         }
     }

--- a/tests/ExcelMapper/Mappers/BoolMapperTests.cs
+++ b/tests/ExcelMapper/Mappers/BoolMapperTests.cs
@@ -15,7 +15,7 @@ namespace ExcelMapper.Mappers.Tests
             var item = new BoolMapper();
 
             object value = null;
-            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, stringValue), ref value);
+            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, -1, stringValue), ref value);
             Assert.Equal(PropertyMapperResultType.Success, result);
             Assert.Equal(expected, value);
         }
@@ -29,7 +29,7 @@ namespace ExcelMapper.Mappers.Tests
             var item = new BoolMapper();
 
             object value = 1;
-            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, stringValue), ref value);
+            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, -1, stringValue), ref value);
             Assert.Equal(PropertyMapperResultType.Invalid, result);
             Assert.Equal(1, value);
         }

--- a/tests/ExcelMapper/Mappers/ChangeTypeMapperTests.cs
+++ b/tests/ExcelMapper/Mappers/ChangeTypeMapperTests.cs
@@ -35,7 +35,7 @@ namespace ExcelMapper.Mappers.Tests
             var item = new ChangeTypeMapper(type);
 
             object value = 0;
-            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, stringValue), ref value);
+            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, -1, stringValue), ref value);
             Assert.Equal(PropertyMapperResultType.Success, result);
             Assert.Equal(expected, value);
         }
@@ -50,7 +50,7 @@ namespace ExcelMapper.Mappers.Tests
             var item = new ChangeTypeMapper(type);
 
             object value = 1;
-            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, stringValue), ref value);
+            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, -1, stringValue), ref value);
             Assert.Equal(PropertyMapperResultType.Invalid, result);
             Assert.Equal(1, value);
         }

--- a/tests/ExcelMapper/Mappers/ConvertUsingMapperTests.cs
+++ b/tests/ExcelMapper/Mappers/ConvertUsingMapperTests.cs
@@ -34,7 +34,7 @@ namespace ExcelMapper.Mappers.Tests
             var item = new ConvertUsingMapper(converter);
 
             object value = null;
-            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, "string"), ref value);
+            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, -1, "string"), ref value);
             Assert.Equal(PropertyMapperResultType.Success, result);
             Assert.Equal(10, value);
         }

--- a/tests/ExcelMapper/Mappers/DateTimeMapperTests.cs
+++ b/tests/ExcelMapper/Mappers/DateTimeMapperTests.cs
@@ -74,7 +74,7 @@ namespace ExcelMapper.Mappers.Tests
             };
 
             object value = null;
-            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, stringValue), ref value);
+            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, -1, stringValue), ref value);
             Assert.Equal(PropertyMapperResultType.Success, result);
             Assert.Equal(expected, value);
         }
@@ -89,7 +89,7 @@ namespace ExcelMapper.Mappers.Tests
             var item = new DateTimeMapper();
 
             object value = 1;
-            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, stringValue), ref value);
+            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, -1, stringValue), ref value);
             Assert.Equal(PropertyMapperResultType.Invalid, result);
             Assert.Equal(1, value);
         }

--- a/tests/ExcelMapper/Mappers/DictionaryMapperTests.cs
+++ b/tests/ExcelMapper/Mappers/DictionaryMapperTests.cs
@@ -36,7 +36,7 @@ namespace ExcelMapper.Mappers.Tests
             var item = new DictionaryMapper<object>(mapping, comparer);
 
             object value = null;
-            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, stringValue), ref value);
+            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, -1, stringValue), ref value);
             Assert.Equal(expectedType, result);
             Assert.Equal(expectedValue, value);
         }

--- a/tests/ExcelMapper/Mappers/EnumMapperTests.cs
+++ b/tests/ExcelMapper/Mappers/EnumMapperTests.cs
@@ -52,7 +52,7 @@ namespace ExcelMapper.Mappers.Tests
         public void GetProperty_ValidStringValue_ReturnsSuccess(EnumMapper item, string stringValue, Enum expected)
         {
             object value = null;
-            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, stringValue), ref value);
+            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, -1, stringValue), ref value);
             Assert.Equal(PropertyMapperResultType.Success, result);
             Assert.Equal(expected, value);
         }
@@ -70,7 +70,7 @@ namespace ExcelMapper.Mappers.Tests
         public void GetProperty_InvalidStringValue_ReturnsInvalid(EnumMapper item, string stringValue)
         {
             object value = 1;
-            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, stringValue), ref value);
+            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, -1, stringValue), ref value);
             Assert.Equal(PropertyMapperResultType.Invalid, result);
             Assert.Equal(1, value);
         }

--- a/tests/ExcelMapper/Mappers/GuidMapperTests.cs
+++ b/tests/ExcelMapper/Mappers/GuidMapperTests.cs
@@ -23,7 +23,7 @@ namespace ExcelMapper.Mappers.Tests
             var item = new GuidMapper();
 
             object value = null;
-            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, stringValue), ref value);
+            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, -1, stringValue), ref value);
             Assert.Equal(PropertyMapperResultType.Success, result);
             Assert.Equal(expected, value);
         }
@@ -37,7 +37,7 @@ namespace ExcelMapper.Mappers.Tests
             var item = new GuidMapper();
 
             object value = 1;
-            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, stringValue), ref value);
+            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, -1, stringValue), ref value);
             Assert.Equal(PropertyMapperResultType.Invalid, result);
             Assert.Equal(1, value);
         }

--- a/tests/ExcelMapper/Mappers/StringMapperTests.cs
+++ b/tests/ExcelMapper/Mappers/StringMapperTests.cs
@@ -14,7 +14,7 @@ namespace ExcelMapper.Mappers.Tests
             var item = new StringMapper();
 
             object value = 1;
-            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, stringValue), ref value);
+            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, -1, stringValue), ref value);
             Assert.Equal(PropertyMapperResultType.SuccessIfNoOtherSuccess, result);
             Assert.Same(stringValue, value);
         }

--- a/tests/ExcelMapper/Mappers/UriMapperTests.cs
+++ b/tests/ExcelMapper/Mappers/UriMapperTests.cs
@@ -20,7 +20,7 @@ namespace ExcelMapper.Mappers.Tests
             var item = new UriMapper();
 
             object value = null;
-            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, stringValue), ref value);
+            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, -1, stringValue), ref value);
             Assert.Equal(PropertyMapperResultType.Success, result);
             Assert.Equal(expected, value);
         }
@@ -34,7 +34,7 @@ namespace ExcelMapper.Mappers.Tests
             var item = new UriMapper();
 
             object value = 1;
-            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, stringValue), ref value);
+            PropertyMapperResultType result = item.MapCellValue(new ReadCellValueResult(-1, -1, stringValue), ref value);
             Assert.Equal(PropertyMapperResultType.Invalid, result);
             Assert.Equal(1, value);
         }

--- a/tests/ExcelMapper/Transformers/TrimCellValueTransformerTests.cs
+++ b/tests/ExcelMapper/Transformers/TrimCellValueTransformerTests.cs
@@ -12,7 +12,7 @@ namespace ExcelMapper.Transformers.Tests
         public void TransformStringValue_Invoke_ReturnsExpected(string stringValue, string expected)
         {
             var transformer = new TrimCellValueTransformer();
-            Assert.Equal(expected, transformer.TransformStringValue(null, 0, new ReadCellValueResult(-1, stringValue)));
+            Assert.Equal(expected, transformer.TransformStringValue(null, 0, new ReadCellValueResult(-1, -1, stringValue)));
         }
     }
 }

--- a/tests/ExcelMapper/ValuePipelineExtensionsTests.cs
+++ b/tests/ExcelMapper/ValuePipelineExtensionsTests.cs
@@ -275,9 +275,11 @@ namespace ExcelMapper.Tests
         [Fact]
         public void WithConverter_SuccessConverter_ReturnsExpected()
         {
-            ConvertUsingSimpleMapperDelegate<string> converter = stringValue =>
+            ConvertUsingSimpleMapperDelegate<string> converter = cell =>
             {
-                Assert.Equal("stringValue", stringValue);
+                Assert.Equal("stringValue", cell.StringValue);
+                Assert.Equal(-1, cell.ColumnIndex);
+                Assert.Equal(-1, cell.RowIndex);
                 return "abc";
             };
 
@@ -286,7 +288,7 @@ namespace ExcelMapper.Tests
             ConvertUsingMapper item = propertyMap.Pipeline.CellValueMappers.OfType<ConvertUsingMapper>().Single();
 
             object value = null;
-            PropertyMapperResultType result = item.Converter(new ReadCellValueResult(-1, "stringValue"), ref value);
+            PropertyMapperResultType result = item.Converter(new ReadCellValueResult(-1, -1, "stringValue"), ref value);
             Assert.Equal(PropertyMapperResultType.Success, result);
             Assert.Equal("abc", value);
         }
@@ -294,9 +296,11 @@ namespace ExcelMapper.Tests
         [Fact]
         public void WithConverter_InvalidConverter_ReturnsExpected()
         {
-            ConvertUsingSimpleMapperDelegate<string> converter = stringValue =>
+            ConvertUsingSimpleMapperDelegate<string> converter = cell =>
             {
-                Assert.Equal("stringValue", stringValue);
+                Assert.Equal("stringValue", cell.StringValue);
+                Assert.Equal(-1, cell.ColumnIndex);
+                Assert.Equal(-1, cell.RowIndex);
                 throw new NotSupportedException();
             };
 
@@ -305,7 +309,7 @@ namespace ExcelMapper.Tests
             ConvertUsingMapper item = propertyMap.Pipeline.CellValueMappers.OfType<ConvertUsingMapper>().Single();
 
             object value = 1;
-            PropertyMapperResultType result = item.Converter(new ReadCellValueResult(-1, "stringValue"), ref value);
+            PropertyMapperResultType result = item.Converter(new ReadCellValueResult(-1, -1, "stringValue"), ref value);
             Assert.Equal(PropertyMapperResultType.Invalid, result);
             Assert.Equal(1, value);
         }

--- a/tests/Maps/MapUsingTests.cs
+++ b/tests/Maps/MapUsingTests.cs
@@ -29,7 +29,7 @@ namespace ExcelMapper.Tests
             public ConvertUsingValueMap()
             {
                 Map(c => c.StringValue)
-                    .WithConverter(s => s + "extra");
+                    .WithConverter(s => s.StringValue + "extra");
             }
         }
     }


### PR DESCRIPTION
I think it would be good to have this value stored, so it's possible to work with the column index and row index inside the WithConverter extension method, giving the possibility to point it out the position of where the convertion failed inside the excel.