### PR TITLE
Set the default mapping policy to StringMapper

### DIFF
--- a/src/Utilities/AutoMapper.cs
+++ b/src/Utilities/AutoMapper.cs
@@ -157,12 +157,6 @@ namespace ExcelMapper.Utilities
                 emptyFallback = ReconcileFallback(FallbackStrategy.ThrowIfPrimitive, isEmpty: true);
                 invalidFallback = ReconcileFallback(FallbackStrategy.ThrowIfPrimitive, isEmpty: false);
             }
-            else if (type == typeof(string) || type == typeof(object) || type == typeof(IConvertible))
-            {
-                mapper = new StringMapper();
-                emptyFallback = ReconcileFallback(FallbackStrategy.SetToDefaultValue, isEmpty: true);
-                invalidFallback = ReconcileFallback(FallbackStrategy.SetToDefaultValue, isEmpty: false);
-            }
             else if (type == typeof(Uri))
             {
                 mapper = new UriMapper();
@@ -177,10 +171,9 @@ namespace ExcelMapper.Utilities
             }
             else
             {
-                mapper = null;
-                emptyFallback = null;
-                invalidFallback = null;
-                return false;
+                mapper = new StringMapper();
+                emptyFallback = ReconcileFallback(FallbackStrategy.SetToDefaultValue, isEmpty: true);
+                invalidFallback = ReconcileFallback(FallbackStrategy.SetToDefaultValue, isEmpty: false);
             }
 
             return true;

--- a/tests/Maps/MapCustomTypeTests.cs
+++ b/tests/Maps/MapCustomTypeTests.cs
@@ -1,0 +1,50 @@
+﻿using Xunit;
+
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit {}
+}
+
+namespace ExcelMapper.Tests
+{
+    public class MapRecordTests
+    {
+        [Fact]
+        public void ReadRow_AutoMappedRecord_ReturnsExpected()
+        {
+            using var importer = Helpers.GetImporter("Numbers.xlsx");
+            importer.Configuration.RegisterClassMap<DefaultRecordClassMap>();
+            ExcelSheet sheet = importer.ReadSheet();
+            sheet.ReadHeading();
+
+            // Valid cell value.
+            var row1 = sheet.ReadRow<RecordClass>();
+            Assert.Equal(2, row1.IntRecord.Value);
+            
+            // Empty value
+            var row2 = sheet.ReadRow<RecordClass>();
+            Assert.Null(row2.IntRecord);
+
+            // Invalid value
+            var row3 = sheet.ReadRow<RecordClass>();
+            Assert.Null(row3.IntRecord);
+        }
+
+        private record IntRecord(int Value);
+
+        private class RecordClass
+        {
+            public IntRecord IntRecord { get; private set; }
+        }
+
+        private class DefaultRecordClassMap : ExcelClassMap<RecordClass>
+        {
+            public DefaultRecordClassMap()
+            {
+                Map(u => u.IntRecord)
+                    .WithConverter(v => new IntRecord(int.Parse(v)))
+                    .WithColumnName("Value");
+            }
+        }
+    }
+}


### PR DESCRIPTION
To add the ability to map custom types (#87 ), I suggest making StringMapper the default mapper