### PR TITLE
Add csv support

### DIFF
--- a/src/ExcelImporter.cs
+++ b/src/ExcelImporter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using ExcelDataReader;
+using ExcelMapper.Utilities;
 
 namespace ExcelMapper
 {
@@ -41,6 +42,39 @@ namespace ExcelMapper
             }
 
             Reader = ExcelReaderFactory.CreateReader(stream);
+        }
+
+                /// <summary>
+        /// Constructs an importer that reads an Excel file from a stream.
+        /// </summary>
+        /// <param name="stream">A stream containing the Excel file bytes.</param>
+        /// <param name="extension">The extension of the file (.xslx, .csv ...).</param>
+        public ExcelImporter(Stream stream, string extension)
+        {
+            if (stream == null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+            if (extension is null)
+            {
+                throw new ArgumentNullException(nameof(extension));
+            }
+            if (!FileUtils.IsSupportedExtension(extension))
+            {
+                throw new ArgumentException(nameof(stream));
+            }
+
+            if (FileUtils.IsCsvExtension(extension))
+            {
+                Reader = ExcelReaderFactory.CreateCsvReader(stream);
+                return;
+            }
+            if (FileUtils.IsExcelExtension(extension))
+            {
+                Reader = ExcelReaderFactory.CreateReader(stream);
+                return;
+            }
+            throw new ArgumentException(nameof(stream));
         }
 
         /// <summary>

--- a/src/Utilities/FileUtils.cs
+++ b/src/Utilities/FileUtils.cs
@@ -1,0 +1,133 @@
+using System;
+
+namespace ExcelMapper.Utilities;
+
+/// <summary>
+/// Contains file extension constants for supported file formats.
+/// </summary>
+public static class FileUtils
+{
+    #region CSV Extensions
+    /// <summary>
+    /// Comma-separated values file extension.
+    /// </summary>
+    public const string Csv = ".csv";
+    #endregion
+
+    #region Excel Extensions
+    /// <summary>
+    /// Excel 97-2003 workbook file extension.
+    /// </summary>
+    public const string Xls = ".xls";
+    
+    /// <summary>
+    /// Excel workbook file extension.
+    /// </summary>
+    public const string Xlsx = ".xlsx";
+    
+    /// <summary>
+    /// Excel macro-enabled workbook file extension.
+    /// </summary>
+    public const string Xlsm = ".xlsm";
+    
+    /// <summary>
+    /// Excel binary workbook file extension.
+    /// </summary>
+    public const string Xlsb = ".xlsb";
+    #endregion
+
+
+    #region Collections
+    /// <summary>
+    /// All supported CSV file extensions.
+    /// </summary>
+    public static readonly string[] CsvExtensions = 
+    {
+        Csv
+    };
+
+    /// <summary>
+    /// All supported Excel file extensions.
+    /// </summary>
+    public static readonly string[] ExcelExtensions = 
+    {
+        Xls,
+        Xlsx,
+        Xlsm,
+        Xlsb
+    };
+
+    /// <summary>
+    /// All supported file extensions for spreadsheet processing.
+    /// </summary>
+    public static readonly string[] AllSupportedExtensions =
+    [
+        Csv,
+        Xls,
+        Xlsx,
+        Xlsm,
+        Xlsb
+    ];
+    #endregion
+
+    #region Helper Methods
+    /// <summary>
+    /// Determines if the specified extension is a CSV file.
+    /// </summary>
+    /// <param name="extension">The file extension to check (case-insensitive).</param>
+    /// <returns>True if the extension represents a CSV file; otherwise, false.</returns>
+    public static bool IsCsvExtension(string extension)
+    {
+        if (string.IsNullOrWhiteSpace(extension))
+            return false;
+
+        return string.Equals(extension, Csv, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Determines if the specified extension is an Excel file.
+    /// </summary>
+    /// <param name="extension">The file extension to check (case-insensitive).</param>
+    /// <returns>True if the extension represents an Excel file; otherwise, false.</returns>
+    public static bool IsExcelExtension(string extension)
+    {
+        if (string.IsNullOrWhiteSpace(extension))
+            return false;
+
+        return Array.Exists(ExcelExtensions, 
+            ext => string.Equals(ext, extension, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Determines if the specified extension is supported for processing.
+    /// </summary>
+    /// <param name="extension">The file extension to check (case-insensitive).</param>
+    /// <returns>True if the extension is supported; otherwise, false.</returns>
+    public static bool IsSupportedExtension(string extension)
+    {
+        if (string.IsNullOrWhiteSpace(extension))
+            return false;
+
+        return Array.Exists(AllSupportedExtensions,
+            ext => string.Equals(ext, extension, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Normalizes a file extension by ensuring it starts with a dot and is lowercase.
+    /// </summary>
+    /// <param name="extension">The file extension to normalize.</param>
+    /// <returns>The normalized extension, or null if input is invalid.</returns>
+    public static string? NormalizeExtension(string? extension)
+    {
+        if (string.IsNullOrWhiteSpace(extension))
+            return null;
+
+        extension = extension.Trim();
+        
+        if (!extension.StartsWith("."))
+            extension = "." + extension;
+
+        return extension.ToLowerInvariant();
+    }
+    #endregion
+}


### PR DESCRIPTION
## PR Description: Add CSV File Support

This PR introduces support for reading CSV files in addition to the existing Excel formats.

### Changes Made

- **Added `FileUtils.cs`:** A new utility class that provides constants and helper methods for working with file extensions. This includes methods to check for supported CSV and Excel extensions.
- **Updated `ExcelImporter.cs`:**
    - Added a new constructor that accepts a file extension as a parameter.
    - The importer now uses `ExcelReaderFactory.CreateCsvReader` when a CSV file extension is provided.
    - Added validation to ensure that only supported file extensions are processed.

### How to Use

To import a CSV file, you can now use the new `ExcelImporter` constructor:

```csharp
using (var stream = File.OpenRead("data.csv"))
{
    var importer = new ExcelImporter(stream, ".csv");
    // ...
}
```
